### PR TITLE
✨ feat(handbook-dotnet): add dotnet-test and dotnet-dependency skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,19 +1,19 @@
 {
   "name": "cc-handbook",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "owner": {
     "name": "nikiforovall",
     "email": "nikiforovall@github.com"
   },
   "metadata": {
     "description": "Official marketplace for Claude Code Handbook plugins and extensions",
-    "version": "1.17.0"
+    "version": "1.19.0"
   },
   "repository": "https://github.com/nikiforovall/claude-code-rules",
   "plugins": [
     {
       "name": "handbook",
-      "version": "1.17.0",
+      "version": "1.19.0",
       "description": "Core Claude Code handbook with best practices and essential tools",
       "author": {
         "name": "nikiforovall",
@@ -34,7 +34,7 @@
     },
     {
       "name": "handbook-extras",
-      "version": "1.17.0",
+      "version": "1.19.0",
       "description": "Extended features and experimental tools for Claude Code Handbook",
       "author": {
         "name": "nikiforovall",
@@ -53,7 +53,7 @@
     },
     {
       "name": "handbook-qa",
-      "version": "1.17.0",
+      "version": "1.19.0",
       "description": "Browser automation and QA testing tools with Playwright MCP integration",
       "author": {
         "name": "nikiforovall",
@@ -73,8 +73,8 @@
     },
     {
       "name": "handbook-dotnet",
-      "version": "1.17.0",
-      "description": ".NET development tools including automatic CSharpier formatting for C# files and dotnet run file support",
+      "version": "1.19.0",
+      "description": ".NET development tools including CSharpier formatting, dotnet run file support, selective unit testing, and dependency investigation",
       "author": {
         "name": "nikiforovall",
         "url": "https://github.com/nikiforovall"
@@ -88,14 +88,19 @@
         "csharpier",
         "hooks",
         "automation",
-        "scripting"
+        "scripting",
+        "testing",
+        "xunit",
+        "unit-tests",
+        "dependencies",
+        "nuget"
       ],
       "homepage": "https://nikiforovall.blog/claude-code-rules/",
       "strict": true
     },
     {
       "name": "handbook-microsoft-docs",
-      "version": "1.17.0",
+      "version": "1.19.0",
       "description": "Microsoft Learn MCP server for searching and fetching official Microsoft and Azure documentation",
       "author": {
         "name": "nikiforovall",
@@ -116,7 +121,7 @@
     },
     {
       "name": "handbook-context7",
-      "version": "1.17.0",
+      "version": "1.19.0",
       "description": "Context7 MCP server for fetching latest library documentation from official sources",
       "author": {
         "name": "nikiforovall",
@@ -136,7 +141,7 @@
     },
     {
       "name": "handbook-sounds",
-      "version": "1.17.0",
+      "version": "1.19.0",
       "description": "Audio feedback for Claude Code events on Windows using PowerShell sounds",
       "author": {
         "name": "nikiforovall",
@@ -158,7 +163,7 @@
     },
     {
       "name": "handbook-git-worktree",
-      "version": "1.17.0",
+      "version": "1.19.0",
       "description": "Git worktree management for working on multiple branches simultaneously",
       "author": {
         "name": "nikiforovall",
@@ -179,7 +184,7 @@
     },
     {
       "name": "handbook-structured-plan-mode",
-      "version": "1.17.0",
+      "version": "1.19.0",
       "description": "Structured planning methodology for complex feature implementations through systematic task decomposition",
       "author": {
         "name": "nikiforovall",
@@ -200,7 +205,7 @@
     },
     {
       "name": "handbook-agent-spec-kit",
-      "version": "1.17.0",
+      "version": "1.19.0",
       "description": "Spec-driven development workflow system with structured phases: Requirements → Design → Tasks → Implementation",
       "author": {
         "name": "Vitalii Matviichuk",
@@ -223,7 +228,7 @@
     },
     {
       "name": "handbook-nano-banana",
-      "version": "1.17.0",
+      "version": "1.19.0",
       "description": "Python scripting and Gemini image generation using uv with inline script dependencies",
       "author": {
         "name": "nikiforovall",
@@ -244,7 +249,7 @@
     },
     {
       "name": "handbook-glab",
-      "version": "1.17.0",
+      "version": "1.19.0",
       "description": "GitLab CLI (glab) expertise for managing merge requests, issues, CI/CD pipelines, and repositories",
       "author": {
         "name": "nikiforovall",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,22 @@
 {
     "workbench.colorCustomizations": {
-        "activityBar.activeBackground": "#b32b00",
-        "activityBar.background": "#b32b00",
+        "activityBar.activeBackground": "#518117",
+        "activityBar.background": "#518117",
         "activityBar.foreground": "#e7e7e7",
         "activityBar.inactiveForeground": "#e7e7e799",
-        "activityBarBadge.background": "#00bf2e",
-        "activityBarBadge.foreground": "#e7e7e7",
+        "activityBarBadge.background": "#78b5e7",
+        "activityBarBadge.foreground": "#15202b",
         "commandCenter.border": "#e7e7e799",
-        "sash.hoverBorder": "#b32b00",
-        "statusBar.background": "#801f00",
+        "sash.hoverBorder": "#518117",
+        "statusBar.background": "#36560f",
         "statusBar.foreground": "#e7e7e7",
-        "statusBarItem.hoverBackground": "#b32b00",
-        "statusBarItem.remoteBackground": "#801f00",
+        "statusBarItem.hoverBackground": "#518117",
+        "statusBarItem.remoteBackground": "#36560f",
         "statusBarItem.remoteForeground": "#e7e7e7",
-        "titleBar.activeBackground": "#801f00",
+        "titleBar.activeBackground": "#36560f",
         "titleBar.activeForeground": "#e7e7e7",
-        "titleBar.inactiveBackground": "#801f0099",
+        "titleBar.inactiveBackground": "#36560f99",
         "titleBar.inactiveForeground": "#e7e7e799"
     },
-    "peacock.color": "#801f00"
+    "peacock.color": "#36560f"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.19.0] - 2025-12-20
+
+### Added
+- New `dotnet-dependency` skill in handbook-dotnet plugin for investigating dependencies and security auditing
+
+## [1.18.0] - 2025-12-20
+
+### Added
+- New `dotnet-test` skill in handbook-dotnet plugin for selective unit testing with xUnit focus
+
 ## [1.17.0] - 2025-12-17
 
 ### Added

--- a/plugins/handbook-agent-spec-kit/.claude-plugin/plugin.json
+++ b/plugins/handbook-agent-spec-kit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handbook-agent-spec-kit",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": "Spec-driven development workflow system with structured phases: Requirements → Design → Tasks → Implementation",
   "author": {
     "name": "Vitalii Matviichuk",

--- a/plugins/handbook-context7/.claude-plugin/plugin.json
+++ b/plugins/handbook-context7/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handbook-context7",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": "Context7 MCP server for fetching latest library documentation from official sources",
   "author": {
     "name": "nikiforovall",

--- a/plugins/handbook-dotnet/.claude-plugin/plugin.json
+++ b/plugins/handbook-dotnet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handbook-dotnet",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": ".NET development tools including automatic CSharpier formatting for C# files and dotnet run file support",
   "author": {
     "name": "nikiforovall",
@@ -17,9 +17,15 @@
     "development",
     "tools",
     "scripting",
-    "run-files"
+    "run-files",
+    "testing",
+    "xunit",
+    "dependencies",
+    "nuget"
   ],
   "skills": [
-    "./skills/dotnet-run-file"
+    "./skills/dotnet-run-file",
+    "./skills/dotnet-test",
+    "./skills/dotnet-dependency"
   ]
 }

--- a/plugins/handbook-dotnet/skills/dotnet-dependency/SKILL.md
+++ b/plugins/handbook-dotnet/skills/dotnet-dependency/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: dotnet-dependency
+description: This skill should be used when investigating .NET project dependencies, understanding why packages are included, listing references, or auditing for outdated/vulnerable packages.
+allowed-tools: Bash(dotnet nuget why:*), Bash(dotnet list:*), Bash(dotnet outdated:*), Read, Grep, Glob
+---
+
+# .NET Dependencies
+
+Investigate and manage .NET project dependencies using built-in dotnet CLI commands.
+
+## When to Use This Skill
+
+Invoke when the user needs to:
+
+- Understand why a specific NuGet package is included
+- List all project dependencies (NuGet packages or project references)
+- Find outdated or vulnerable packages
+- Trace transitive dependencies
+
+## Quick Reference
+
+| Command                                     | Purpose                               |
+| ------------------------------------------- | ------------------------------------- |
+| `dotnet nuget why <package>`                | Show dependency graph for a package   |
+| `dotnet list package`                       | List NuGet packages                   |
+| `dotnet list package --include-transitive`  | Include transitive dependencies       |
+| `dotnet list reference --project <project>` | List project-to-project references    |
+| `dotnet list package --outdated`            | Find packages with newer versions     |
+| `dotnet list package --vulnerable`          | Find packages with security issues    |
+| `dotnet outdated`                           | (Third-party) Check outdated packages |
+| `dotnet outdated -u`                        | (Third-party) Auto-update packages    |
+
+## Investigate Package Dependencies
+
+To understand why a package is included in your project:
+
+```bash
+# Why is this package included?
+dotnet nuget why Newtonsoft.Json
+
+# For a specific project
+dotnet nuget why path/to/Project.csproj Newtonsoft.Json
+
+# For a specific framework
+dotnet nuget why Newtonsoft.Json --framework net8.0
+```
+
+Output shows the complete dependency chain from your project to the package.
+
+## List NuGet Packages
+
+```bash
+# Direct dependencies only
+dotnet list package
+
+# Include transitive (indirect) dependencies
+dotnet list package --include-transitive
+
+# For a specific project
+dotnet list package --project path/to/Project.csproj
+
+# JSON output for scripting
+dotnet list package --format json
+```
+
+## List Project References
+
+```bash
+# List project-to-project references
+dotnet list reference --project path/to/Project.csproj
+```
+
+### Transitive Project References
+
+No built-in command shows transitive project dependencies. To find if Project A depends on Project B transitively:
+
+1. **Recursive approach**: Run `dotnet list reference` on each referenced project
+2. **Parse .csproj files**: Search for `<ProjectReference>` elements recursively:
+
+```bash
+# Find all ProjectReference elements
+grep -r "ProjectReference" --include="*.csproj" .
+```
+
+## Update Dependencies
+
+### Using dotnet outdated (Third-party)
+
+If installed (`dotnet tool install -g dotnet-outdated-tool`):
+
+```bash
+# Check for outdated packages
+dotnet outdated
+
+# Auto-update to latest versions
+dotnet outdated -u
+
+# Update only specific packages
+dotnet outdated -u -inc PackageName
+```
+
+### Using built-in commands
+
+```bash
+# Check for outdated packages
+dotnet list package --outdated
+
+# Include prerelease versions
+dotnet list package --outdated --include-prerelease
+```
+
+## Progressive Disclosure
+
+For security auditing (vulnerable, deprecated, outdated packages), load **references/security-audit.md**.
+
+## References
+
+- [dotnet nuget why](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-why)
+- [dotnet list reference](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-reference-list)
+- [dotnet list package](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package)

--- a/plugins/handbook-dotnet/skills/dotnet-dependency/references/security-audit.md
+++ b/plugins/handbook-dotnet/skills/dotnet-dependency/references/security-audit.md
@@ -1,0 +1,132 @@
+# Security Audit for Dependencies
+
+Audit .NET project dependencies for security vulnerabilities, outdated packages, and deprecated libraries.
+
+## Vulnerable Packages
+
+Find packages with known security vulnerabilities:
+
+```bash
+# Check for vulnerable packages
+dotnet list package --vulnerable
+
+# Include transitive dependencies
+dotnet list package --vulnerable --include-transitive
+
+# JSON output for CI/CD
+dotnet list package --vulnerable --format json
+```
+
+Requirements: .NET SDK 9.0.300+ for vulnerability scanning.
+
+## Outdated Packages
+
+### Using built-in commands
+
+```bash
+# Find packages with newer versions
+dotnet list package --outdated
+
+# Include prerelease versions
+dotnet list package --outdated --include-prerelease
+
+# Limit to patch updates only (same major.minor)
+dotnet list package --outdated --highest-patch
+
+# Limit to minor updates only (same major)
+dotnet list package --outdated --highest-minor
+
+# JSON output
+dotnet list package --outdated --format json
+```
+
+### Using dotnet outdated (Third-party)
+
+Install: `dotnet tool install -g dotnet-outdated-tool`
+
+```bash
+# Check for outdated packages (nicer output)
+dotnet outdated
+
+# Auto-update all packages to latest
+dotnet outdated -u
+
+# Include specific packages only
+dotnet outdated -u -inc PackageName
+
+# Exclude specific packages
+dotnet outdated -u -exc PackageName
+
+# Update to highest minor version only
+dotnet outdated -u -vl Minor
+
+# Update to highest patch version only
+dotnet outdated -u -vl Patch
+```
+
+## Deprecated Packages
+
+```bash
+# Find deprecated packages
+dotnet list package --deprecated
+
+# Include transitive dependencies
+dotnet list package --deprecated --include-transitive
+```
+
+## Framework-Specific Auditing
+
+```bash
+# Audit specific framework only
+dotnet list package --outdated --framework net8.0
+dotnet list package --vulnerable --framework net8.0
+```
+
+## CI/CD Integration
+
+Generate JSON reports for automated pipelines:
+
+```bash
+# Full security report
+dotnet list package --vulnerable --include-transitive --format json > vulnerable.json
+dotnet list package --outdated --format json > outdated.json
+dotnet list package --deprecated --format json > deprecated.json
+```
+
+## Combined Workflow
+
+For a comprehensive security audit:
+
+```bash
+# 1. Check for vulnerabilities (critical)
+dotnet list package --vulnerable --include-transitive
+
+# 2. Check for deprecated packages
+dotnet list package --deprecated
+
+# 3. Check for outdated packages
+dotnet list package --outdated
+
+# 4. Update packages (using dotnet outdated)
+dotnet outdated -u
+```
+
+## Package Source Configuration
+
+Vulnerability data comes from configured NuGet sources. Ensure your `nuget.config` includes vulnerability-aware sources:
+
+```xml
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <auditSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </auditSources>
+</configuration>
+```
+
+## References
+
+- [dotnet list package](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package)
+- [dotnet-outdated tool](https://github.com/dotnet-outdated/dotnet-outdated)

--- a/plugins/handbook-dotnet/skills/dotnet-test/SKILL.md
+++ b/plugins/handbook-dotnet/skills/dotnet-test/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: dotnet-test
+description: This skill should be used when running .NET tests selectively with a build-first, test-targeted workflow. Use it for running tests with xUnit focus.
+allowed-tools: Bash(dotnet build:*), Bash(dotnet test:*), Read, Grep, Glob
+---
+
+# .NET Test Runner
+
+Run .NET tests selectively using a build-first, test-targeted workflow optimized for development speed.
+
+## Core Workflow
+
+Follow this workflow to run tests efficiently:
+
+### Step 1: Build Solution First
+
+Build the entire solution with minimal output to catch compile errors early:
+
+```bash
+dotnet build -p:WarningLevel=0 /clp:ErrorsOnly --verbosity quiet
+```
+
+### Step 2: Run Specific Project Tests
+
+Run tests for the specific test project with `--no-build` to skip redundant compilation:
+
+```bash
+dotnet test path/to/project --no-build --verbosity quiet
+```
+
+### Step 3: Filter When Targeting Specific Tests
+
+Narrow down to specific tests using filter expressions:
+
+```bash
+# By method name (contains)
+dotnet test --no-build --filter "Name~MyTestMethod"
+
+# By class name (exact match)
+dotnet test --no-build --filter "ClassName=MyNamespace.MyTestClass"
+
+# Combined filters
+dotnet test --no-build --filter "Name~Create|Name~Update"
+```
+
+## Quick Reference
+
+### Commands
+
+| Command                                                            | Purpose                              |
+| ------------------------------------------------------------------ | ------------------------------------ |
+| `dotnet build -p:WarningLevel=0 /clp:ErrorsOnly --verbosity quiet` | Build solution with minimal output   |
+| `dotnet test path/to/Tests.csproj --no-build`                      | Run project tests (skip build)       |
+| `dotnet test --no-build --logger "console;verbosity=detailed"`     | Show ITestOutputHelper output        |
+| `dotnet test --no-build --filter "..."`                            | Run filtered tests                   |
+| `dotnet test --no-build --list-tests`                              | List available tests without running |
+
+### Filter Operators
+
+| Operator | Meaning          | Example                                                        |
+| -------- | ---------------- | -------------------------------------------------------------- |
+| `=`      | Exact match      | `ClassName=MyTests`                                            |
+| `!=`     | Not equal        | `Name!=SkipThis`                                               |
+| `~`      | Contains         | `Name~Create`                                                  |
+| `!~`     | Does not contain | `Name!~Integration`                                            |
+| `\|`     | OR               | `Name~Test1\|Name~Test2` (note '\|' is an escape for markdown) |
+| `&`      | AND              | `Name~User&Category=Unit`                                      |
+
+### xUnit Filter Properties
+
+| Property             | Description                   | Example                                  |
+| -------------------- | ----------------------------- | ---------------------------------------- |
+| `FullyQualifiedName` | Full test name with namespace | `FullyQualifiedName~MyNamespace.MyClass` |
+| `DisplayName`        | Test display name             | `DisplayName=My_Test_Name`               |
+| `Name`               | Method name                   | `Name~ShouldCreate`                      |
+| `Category`           | Trait category                | `Category=Unit`                          |
+
+### Common Filter Patterns
+
+```bash
+# Run tests containing "Create" in method name
+dotnet test --no-build --filter "Name~Create"
+
+# Run tests in a specific class
+dotnet test --no-build --filter "ClassName=MyNamespace.UserServiceTests"
+
+# Run tests matching namespace pattern
+dotnet test --no-build --filter "FullyQualifiedName~MyApp.Tests.Unit"
+
+# Run tests with specific trait
+dotnet test --no-build --filter "Category=Integration"
+
+# Exclude slow tests
+dotnet test --no-build --filter "Category!=Slow"
+
+# Combined: class AND method pattern
+dotnet test --no-build --filter "ClassName=OrderTests&Name~Validate"
+```
+
+### ITestOutputHelper Output
+
+To see output from xUnit's `ITestOutputHelper`, use the console logger with detailed verbosity:
+
+```bash
+dotnet test --no-build --logger "console;verbosity=detailed"
+```
+
+## Framework Differences
+
+This skill focuses on **xUnit**. For MSTest or NUnit, filter property names differ:
+
+| Property       | xUnit       | MSTest         | NUnit       |
+| -------------- | ----------- | -------------- | ----------- |
+| Method name    | `Name`      | `Name`         | `Name`      |
+| Class name     | `ClassName` | `ClassName`    | `ClassName` |
+| Category/Trait | `Category`  | `TestCategory` | `Category`  |
+| Priority       | -           | `Priority`     | `Priority`  |
+
+## Progressive Disclosure
+
+For advanced debugging scenarios, load additional references:
+
+- **references/blame-mode.md** - Debugging test crashes and hangs with `--blame`
+- **references/parallel-execution.md** - Controlling parallel test execution
+
+Load these references when:
+
+- Tests are crashing or hanging unexpectedly
+- Diagnosing test isolation issues
+- Optimizing test run performance
+
+## When to Use This Skill
+
+Invoke when the user needs to:
+
+- Run targeted tests during development
+- Filter tests by method or class name
+- Understand test output and filtering options
+- Debug failing or hanging tests

--- a/plugins/handbook-dotnet/skills/dotnet-test/references/blame-mode.md
+++ b/plugins/handbook-dotnet/skills/dotnet-test/references/blame-mode.md
@@ -1,0 +1,165 @@
+# Blame Mode for Test Debugging
+
+Blame mode helps identify tests that cause crashes, hangs, or process termination. It sequences test execution and logs which test was running when a failure occurred.
+
+## When to Use Blame Mode
+
+- Tests crash the test host process
+- Tests hang indefinitely
+- Debugging intermittent test failures
+- Identifying tests that corrupt shared state
+- CI pipelines fail mysteriously
+
+## Basic Blame Mode
+
+Enable blame mode to log test sequence and identify the last running test:
+
+```bash
+dotnet test --blame
+```
+
+Output: Creates a `Sequence.xml` file in `TestResults/` showing test execution order.
+
+## Crash Dump Collection
+
+Collect crash dumps when tests crash the host process:
+
+```bash
+# Collect crash dump on failure
+dotnet test --blame-crash
+
+# Specify dump type (mini or full)
+dotnet test --blame-crash --blame-crash-dump-type mini
+dotnet test --blame-crash --blame-crash-dump-type full
+
+# Collect dump on unexpected exit
+dotnet test --blame-crash-collect-always
+```
+
+### Dump Types
+
+| Type   | Size         | Content                      |
+| ------ | ------------ | ---------------------------- |
+| `mini` | Small (~5MB) | Stack traces, loaded modules |
+| `full` | Large        | Complete process memory      |
+
+Recommendation: Start with `mini` dumps. Use `full` only when mini dumps lack sufficient detail.
+
+## Hang Detection
+
+Detect and collect information when tests hang:
+
+```bash
+# Detect hangs with timeout
+dotnet test --blame-hang --blame-hang-timeout 5m
+
+# Specify dump type for hangs
+dotnet test --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 3m
+```
+
+### Timeout Format
+
+- `5m` - 5 minutes
+- `30s` - 30 seconds
+- `1h` - 1 hour
+- `5000ms` - 5000 milliseconds
+
+## Combined Usage
+
+For comprehensive debugging, combine options:
+
+```bash
+dotnet test \
+  --blame \
+  --blame-crash \
+  --blame-crash-dump-type mini \
+  --blame-hang \
+  --blame-hang-timeout 5m \
+  --blame-hang-dump-type mini
+```
+
+## Results Location
+
+Blame data is saved to:
+
+```
+TestResults/
+├── {guid}/
+│   ├── Sequence.xml          # Test execution sequence
+│   ├── crash_dump.dmp        # Crash dump (if crash occurred)
+│   └── hang_dump.dmp         # Hang dump (if timeout occurred)
+```
+
+Specify custom location:
+
+```bash
+dotnet test --blame --results-directory ./MyResults
+```
+
+## Analyzing Results
+
+### Reading Sequence.xml
+
+The sequence file shows tests in execution order:
+
+```xml
+<TestSequence>
+  <Test Name="Test1" Source="Tests.dll" />
+  <Test Name="Test2" Source="Tests.dll" />  <!-- Last test before crash -->
+</TestSequence>
+```
+
+### Analyzing Dumps
+
+Use Visual Studio or WinDbg to analyze `.dmp` files:
+
+```bash
+# Windows: Open in Visual Studio
+# Linux/Mac: Use lldb or dotnet-dump
+dotnet-dump analyze crash_dump.dmp
+```
+
+## CI/CD Integration
+
+For CI pipelines, enable blame mode to diagnose failures:
+
+```bash
+dotnet test \
+  --blame \
+  --blame-crash \
+  --blame-hang --blame-hang-timeout 10m \
+  --logger trx \
+  --results-directory ./TestResults
+```
+
+Artifacts to preserve:
+
+- `TestResults/` directory
+- Any `.dmp` files
+- `Sequence.xml` files
+
+## Common Scenarios
+
+### Scenario: Random test failures in CI
+
+```bash
+dotnet test --blame --blame-crash
+```
+
+Check `Sequence.xml` to find which test was running during failure.
+
+### Scenario: Tests hang indefinitely
+
+```bash
+dotnet test --blame-hang --blame-hang-timeout 5m --blame-hang-dump-type full
+```
+
+Analyze the hang dump to find deadlocks or infinite loops.
+
+### Scenario: Test host crashes with no output
+
+```bash
+dotnet test --blame-crash --blame-crash-dump-type full --blame-crash-collect-always
+```
+
+Use full dump to get complete memory state for analysis.

--- a/plugins/handbook-dotnet/skills/dotnet-test/references/parallel-execution.md
+++ b/plugins/handbook-dotnet/skills/dotnet-test/references/parallel-execution.md
@@ -1,0 +1,170 @@
+# Parallel Test Execution Control
+
+By default, .NET test runner executes tests in parallel for performance. This reference covers controlling parallelism at different levels.
+
+## Default Behavior
+
+- **Solution level**: Test projects run in parallel
+- **Project level**: Depends on test framework settings
+- **Multi-targeted projects**: Target frameworks run in parallel (.NET 9+)
+
+## Controlling Parallelism
+
+### Solution/Project Level
+
+Disable parallel execution across target frameworks (multi-targeted projects):
+
+```bash
+dotnet test -p:TestTfmsInParallel=false
+```
+
+Limit parallel test assemblies:
+
+```bash
+dotnet test -p:MaxCpuCount=1
+```
+
+### xUnit Parallelism
+
+xUnit runs test collections in parallel by default. Control via `xunit.runner.json`:
+
+```json
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 4
+}
+```
+
+Or via assembly attribute in code:
+
+```csharp
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+```
+
+### Collection-Based Control
+
+Group related tests into collections to control execution:
+
+```csharp
+[Collection("Database")]
+public class UserRepositoryTests { }
+
+[Collection("Database")]
+public class OrderRepositoryTests { }
+```
+
+Tests in the same collection run sequentially; different collections run in parallel.
+
+To disable parallelism for a collection:
+
+```csharp
+[CollectionDefinition("Database", DisableParallelization = true)]
+public class DatabaseCollection { }
+```
+
+## When to Disable Parallelism
+
+### Shared Resources
+
+- Database connections with transactions
+- File system operations on same files
+- In-memory caches or singletons
+- External service dependencies with rate limits
+
+### Test Isolation Issues
+
+- Tests modify global state
+- Tests use static fields
+- Tests share test fixtures incorrectly
+
+### Debugging
+
+- Reproducing intermittent failures
+- Analyzing test execution order
+- Profiling individual tests
+
+## Performance Optimization
+
+### Maximize Parallelism
+
+For well-isolated tests, increase parallel threads:
+
+```json
+{
+  "maxParallelThreads": -1
+}
+```
+
+`-1` uses processor count × 1 thread.
+
+### Balance Memory and Speed
+
+For memory-intensive tests, limit parallelism:
+
+```json
+{
+  "maxParallelThreads": 2
+}
+```
+
+### Parallel Categories
+
+Run integration tests sequentially, unit tests in parallel:
+
+```bash
+# Fast unit tests (parallel)
+dotnet test --filter "Category=Unit"
+
+# Slow integration tests (sequential)
+dotnet test --filter "Category=Integration" -p:MaxCpuCount=1
+```
+
+## Command Line Options
+
+| Option                                            | Purpose                        |
+| ------------------------------------------------- | ------------------------------ |
+| `-p:TestTfmsInParallel=false`                     | Disable multi-TFM parallelism  |
+| `-p:MaxCpuCount=N`                                | Limit parallel test assemblies |
+| `-- RunConfiguration.DisableParallelization=true` | Disable via runsettings        |
+
+## RunSettings File
+
+Create `test.runsettings` for persistent configuration:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <DisableParallelization>true</DisableParallelization>
+    <MaxCpuCount>1</MaxCpuCount>
+  </RunConfiguration>
+</RunSettings>
+```
+
+Use with:
+
+```bash
+dotnet test --settings test.runsettings
+```
+
+## Troubleshooting
+
+### Symptom: Random test failures in CI
+
+Cause: Tests share state without proper isolation.
+
+Fix: Use `[Collection]` to group dependent tests, or disable parallelism temporarily while fixing isolation issues.
+
+### Symptom: Tests pass individually, fail together
+
+Cause: Parallel execution exposes race conditions.
+
+Fix: Identify shared resources. Use dependency injection for test-scoped resources.
+
+### Symptom: High memory usage during tests
+
+Cause: Too many parallel test processes.
+
+Fix: Reduce `maxParallelThreads` or use `-p:MaxCpuCount=2`.

--- a/plugins/handbook-extras/.claude-plugin/plugin.json
+++ b/plugins/handbook-extras/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handbook-extras",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": "Extended features and experimental tools for Claude Code Handbook",
   "author": {
     "name": "nikiforovall",

--- a/plugins/handbook-git-worktree/.claude-plugin/plugin.json
+++ b/plugins/handbook-git-worktree/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handbook-git-worktree",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": "Git worktree management for working on multiple branches simultaneously",
   "author": {
     "name": "nikiforovall",

--- a/plugins/handbook-glab/.claude-plugin/plugin.json
+++ b/plugins/handbook-glab/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handbook-glab",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": "GitLab CLI (glab) expertise for managing merge requests, issues, CI/CD pipelines, and repositories from the command line",
   "author": {
     "name": "nikiforovall",

--- a/plugins/handbook-microsoft-docs/.claude-plugin/plugin.json
+++ b/plugins/handbook-microsoft-docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handbook-microsoft-docs",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": "Microsoft Learn MCP server for searching and fetching official Microsoft and Azure documentation",
   "author": {
     "name": "nikiforovall",

--- a/plugins/handbook-nano-banana/.claude-plugin/plugin.json
+++ b/plugins/handbook-nano-banana/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handbook-nano-banana",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": "Python scripting and Gemini image generation using uv with inline script dependencies",
   "author": {
     "name": "nikiforovall",

--- a/plugins/handbook-qa/.claude-plugin/plugin.json
+++ b/plugins/handbook-qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handbook-qa",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": "Browser automation and QA testing tools with Playwright MCP integration",
   "author": {
     "name": "nikiforovall",

--- a/plugins/handbook-sounds/.claude-plugin/plugin.json
+++ b/plugins/handbook-sounds/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handbook-sounds",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": "Audio feedback for Claude Code events on Windows using PowerShell sounds",
   "author": {
     "name": "nikiforovall",

--- a/plugins/handbook-structured-plan-mode/.claude-plugin/plugin.json
+++ b/plugins/handbook-structured-plan-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handbook-structured-plan-mode",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": "Structured planning methodology for complex feature implementations through systematic task decomposition",
   "author": {
     "name": "nikiforovall",

--- a/plugins/handbook/.claude-plugin/plugin.json
+++ b/plugins/handbook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "handbook",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": "Core Claude Code handbook with best practices and essential tools",
   "author": {
     "name": "nikiforovall",

--- a/website/docs/component-reference/skills/dotnet-dependency.mdx
+++ b/website/docs/component-reference/skills/dotnet-dependency.mdx
@@ -1,0 +1,58 @@
+---
+title: "dotnet-dependency"
+sidebar_position: 11
+---
+
+import DotnetDependencySource from '!!raw-loader!../../../../plugins/handbook-dotnet/skills/dotnet-dependency/SKILL.md'
+import CodeBlock from '@theme/CodeBlock';
+
+# Use `dotnet-dependency` skill
+
+<span className="badge badge--handbook-dotnet">handbook-dotnet</span>
+
+Investigate and manage .NET project dependencies using built-in dotnet CLI commands.
+
+This skill helps you understand why packages are included, list all project dependencies, find outdated or vulnerable packages, and trace transitive dependencies.
+
+## When to Use This Skill
+
+Use the `dotnet-dependency` skill when you want to:
+
+- Understand why a specific NuGet package is included (`dotnet nuget why`)
+- List all project dependencies (NuGet packages or project references)
+- Find outdated or vulnerable packages
+- Trace transitive dependencies
+
+## Quick Examples
+
+```bash
+# Why is this package included?
+dotnet nuget why Newtonsoft.Json
+
+# List NuGet packages
+dotnet list package
+
+# Include transitive dependencies
+dotnet list package --include-transitive
+
+# List project references
+dotnet list reference --project path/to/Project.csproj
+
+# Find outdated packages
+dotnet list package --outdated
+
+# Auto-update with dotnet-outdated (third-party)
+dotnet outdated -u
+```
+
+## Skill Specification
+
+<CodeBlock language="markdown">
+{DotnetDependencySource}
+</CodeBlock>
+
+## References
+
+- [dotnet nuget why](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-why)
+- [dotnet list reference](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-reference-list)
+- [dotnet list package](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package)

--- a/website/docs/component-reference/skills/dotnet-test.mdx
+++ b/website/docs/component-reference/skills/dotnet-test.mdx
@@ -1,0 +1,54 @@
+---
+title: "dotnet-test"
+sidebar_position: 10
+---
+
+import DotnetTestSource from '!!raw-loader!../../../../plugins/handbook-dotnet/skills/dotnet-test/SKILL.md'
+import CodeBlock from '@theme/CodeBlock';
+
+# Use `dotnet-test` skill
+
+<span className="badge badge--handbook-dotnet">handbook-dotnet</span>
+
+Run .NET tests selectively using a build-first, test-targeted workflow optimized for development speed with xUnit focus.
+
+This skill helps you run targeted tests during development, filter tests by method or class name, and understand test output and filtering options.
+
+## When to Use This Skill
+
+Use the `dotnet-test` skill when you want to:
+
+- Run targeted tests during development
+- Filter tests by method or class name
+- Understand test output and filtering options
+- Debug failing or hanging tests
+
+## Quick Examples
+
+```bash
+# Step 1: Build solution with minimal output
+dotnet build -p:WarningLevel=0 /clp:ErrorsOnly
+
+# Step 2: Run specific project tests (skip build)
+dotnet test path/to/Tests.csproj --no-build -v detailed
+
+# Step 3: Filter by method name
+dotnet test --no-build --filter "Name~MyTestMethod"
+
+# Filter by class name
+dotnet test --no-build --filter "ClassName=MyNamespace.MyTestClass"
+
+# Show ITestOutputHelper output
+dotnet test --no-build --logger "console;verbosity=detailed"
+```
+
+## Skill Specification
+
+<CodeBlock language="markdown">
+{DotnetTestSource}
+</CodeBlock>
+
+## References
+
+- [dotnet test command](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test) - Official Microsoft documentation
+- [Selective unit tests](https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests) - Filter expression syntax and examples


### PR DESCRIPTION
Add two new skills to handbook-dotnet plugin:

- dotnet-test: Selective unit testing with build-first workflow
  - Filter by method/class name
  - ITestOutputHelper support
  - Blame mode and parallel execution references

- dotnet-dependency: Dependency investigation and management
  - dotnet nuget why for dependency chains
  - dotnet list package/reference commands
  - Security audit for outdated/vulnerable packages
  - dotnet-outdated tool integration

Bump version to 1.19.0