### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # 📖 [Claude Code Handbook](https://nikiforovall.blog/claude-code-rules/)
 
+[![Run in Smithery](https://smithery.ai/badge/skills/nikiforovall)](https://smithery.ai/skills?ns=nikiforovall&utm_source=github&utm_medium=badge)
+
+
 A collection of [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) recommendations and practices.
 
 Learn practical techniques to enhance your AI-assisted development workflow with Claude Code.


### PR DESCRIPTION
## Add skill discoverability badge

Your 6 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/NikiforovAll)](https://smithery.ai/skills?ns=NikiforovAll&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.