### PR TITLE
Add stash command (Ctrl+S) to keyboard shortcuts

### DIFF
--- a/website/docs/tips-and-tricks/keyboard-shortcuts.md
+++ b/website/docs/tips-and-tricks/keyboard-shortcuts.md
@@ -14,6 +14,7 @@ Claude Code supports common keyboard shortcuts to help you edit commands efficie
 | `Ctrl+W` | Delete word |
 | `Ctrl+U` | Delete line |
 | `Ctrl+K` | Delete to end |
+| `Ctrl+S` | Stash prompt (saves draft, auto-restores later) |
 | `↑/↓` | Previous/Next command |
 | `Tab` | Auto-complete |
 | `Ctrl+R` | Search command history |


### PR DESCRIPTION
## Summary

Adds documentation for Claude Code's stash command (`Ctrl+S`) - a feature that lets you temporarily save your prompt draft, send something else, and have it auto-restore.

## Changes

- Added `Ctrl+S` stash shortcut to `website/docs/tips-and-tricks/keyboard-shortcuts.md`

## Stash Command Details

- **Shortcut**: `Ctrl+S` (all platforms: macOS, Windows, Linux)
- **Function**: Like git stash for your prompt - saves draft, auto-restores later
- **Use case**: Save a complex prompt, send a quick question, then continue where you left off

## References

- [Eric Buess on X confirming stash feature](https://x.com/EricBuess/status/1999979691814649970)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)